### PR TITLE
Fix file name constant in AddRange test

### DIFF
--- a/src/ListMmfTests/ListMmfTests.cs
+++ b/src/ListMmfTests/ListMmfTests.cs
@@ -199,7 +199,7 @@ public class ListMmfTests
     [Fact]
     public void AddRange_ShouldWork()
     {
-        const string FileName = $"{nameof(Truncate_ShouldWork)}";
+        const string FileName = $"{nameof(AddRange_ShouldWork)}";
         if (File.Exists(FileName))
         {
             File.Delete(FileName);


### PR DESCRIPTION
## Summary
- use `AddRange_ShouldWork` to name output file for test

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a21d51848083288a72e0c3a4526070