### PR TITLE
Fix enumerator initialization in AddRange

### DIFF
--- a/src/ListMmf/ListMmf.cs
+++ b/src/ListMmf/ListMmf.cs
@@ -109,8 +109,6 @@ public unsafe class ListMmf<T> : ListMmfBase<T>, IReadOnlyList64Mmf<T>, IListMmf
             default:
                 using (var en = collection.GetEnumerator())
                 {
-                    // Do inline Add
-                    Add(en.Current);
                     while (en.MoveNext())
                     {
                         if (currentCount + 1 > _capacity)


### PR DESCRIPTION
## Summary
- ensure AddRange's default enumerator calls MoveNext before reading Current

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a227309a1483289db69bea6f7aea6d