### PR TITLE
Clarify capacity parameter documentation in time series list

### DIFF
--- a/src/ListMmf/ListMmfTimeSeriesDateTimeSeconds.cs
+++ b/src/ListMmf/ListMmfTimeSeriesDateTimeSeconds.cs
@@ -30,7 +30,7 @@ public class ListMmfTimeSeriesDateTimeSeconds : ListMmfBase<int>, IReadOnlyList6
     /// <param name="path">The path to open ReadWrite</param>
     /// <param name="timeSeriesOrder"></param>
     /// <param name="capacity">
-    /// The number of bits to initialize the list.
+    /// The number of items to initialize the list.
     /// If 0, will be set to some default amount for a new file. Is ignored for an existing one.
     /// </param>
     /// <param name="parentHeaderBytes"></param>
@@ -68,7 +68,7 @@ public class ListMmfTimeSeriesDateTimeSeconds : ListMmfBase<int>, IReadOnlyList6
     /// <param name="path">The path to open ReadWrite</param>
     /// <param name="timeSeriesOrder"></param>
     /// <param name="capacity">
-    /// The number of bits to initialize the list.
+    /// The number of items to initialize the list.
     /// If 0, will be set to some default amount for a new file. Is ignored for an existing one.
     /// </param>
     public ListMmfTimeSeriesDateTimeSeconds(string path, TimeSeriesOrder timeSeriesOrder, long capacity = 0)


### PR DESCRIPTION
## Summary
- clarify capacity parameter to reference number of items instead of bits

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a22732a34c83288693d6847a07816e