### PR TITLE
build: enforce 64-bit runtime and cross-arch tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13] # macos-13 is Intel x64, macos-latest is ARM64
-        dotnet-version: ['9.0.x']
+        include:
+          - os: ubuntu-latest
+            arch: x64
+            dotnet-version: '9.0.x'
+          - os: windows-latest
+            arch: x64
+            dotnet-version: '9.0.x'
+          - os: macos-14
+            arch: arm64
+            dotnet-version: '9.0.x'
 
     steps:
     - uses: actions/checkout@v4
@@ -30,13 +38,13 @@ jobs:
       run: dotnet build --no-restore --configuration Release
     
     - name: Test
-      run: dotnet test --no-build --configuration Release --verbosity normal --logger "trx;LogFileName=test-results.trx"
+      run: dotnet test src/ListMmfTests/ListMmfTests.csproj --arch ${{ matrix.arch }} --configuration Release --no-build --logger "trx;LogFileName=test-results.trx"
     
     - name: Upload test results
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: test-results-${{ matrix.os }}-${{ matrix.dotnet-version }}
+        name: test-results-${{ matrix.os }}-${{ matrix.arch }}
         path: '**/test-results.trx'
 
 
@@ -62,5 +70,5 @@ jobs:
     - name: Upload NuGet package
       uses: actions/upload-artifact@v4
       with:
-        name: nuget-package
-        path: ./artifacts/*.nupkg
+          name: nuget-package
+          path: ./artifacts/*.nupkg

--- a/src/ListMmf/ListMmf.csproj
+++ b/src/ListMmf/ListMmf.csproj
@@ -8,7 +8,8 @@
 		<AssemblyName>ListMmf</AssemblyName>
 		<RootNamespace>BruSoftware.ListMmf</RootNamespace>
                 <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-                <Platforms>x64</Platforms>
+                <PlatformTarget>AnyCPU</PlatformTarget>
+                <Prefer32Bit>false</Prefer32Bit>
                 <Configurations>Debug;Release;Mixed</Configurations>
                 <GenerateDocumentationFile>true</GenerateDocumentationFile>
                 <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/ListMmf/ListMmfBase.cs
+++ b/src/ListMmf/ListMmfBase.cs
@@ -141,7 +141,7 @@ public unsafe class ListMmfBase<T> : ListMmfBaseDebug where T : struct
         }
         if (!Environment.Is64BitProcess)
         {
-            throw new ListMmfException("Not supported on 32-bit process. Must be 64-bit for atomic operations on structures of size <= 8 bytes.");
+            throw new PlatformNotSupportedException("Requires a 64-bit process (x64 or ARM64).");
         }
         _width = Unsafe.SizeOf<T>();
         _access = MemoryMappedFileAccess.ReadWrite;

--- a/src/ListMmfBenchmarks/BenchmarkLocks.cs
+++ b/src/ListMmfBenchmarks/BenchmarkLocks.cs
@@ -21,13 +21,9 @@ public unsafe class BenchmarkLocks
     [GlobalSetup]
     public void GlobalSetup()
     {
-        if (!Environment.Is64BitOperatingSystem)
-        {
-            throw new Exception("Not supported on 32-bit operating system. Must be 64-bit for atomic operations on structures of size <= 8 bytes.");
-        }
         if (!Environment.Is64BitProcess)
         {
-            throw new Exception("Not supported on 32-bit process. Must be 64-bit for atomic operations on structures of size <= 8 bytes.");
+            throw new PlatformNotSupportedException("Requires a 64-bit process (x64 or ARM64).");
         }
         const string TestFilePath = @"C:\_HugeArray\Timestamps.btd"; // 9.91 GB of longs
         const int NumTests = 10000000;

--- a/src/ListMmfBenchmarks/BenchmarkRandomReads.cs
+++ b/src/ListMmfBenchmarks/BenchmarkRandomReads.cs
@@ -24,7 +24,7 @@ public unsafe class BenchmarkRandomReads
     {
         if (!Environment.Is64BitProcess)
         {
-            throw new Exception("Not supported on 32-bit process. Must be 64-bit for atomic operations on structures of size <= 8 bytes.");
+            throw new PlatformNotSupportedException("Requires a 64-bit process (x64 or ARM64).");
         }
         const string testFilePath = @"C:\_HugeArray\Timestamps.btd"; // 9.91 GB of longs
         _fs = new FileStream(testFilePath, FileMode.Open);

--- a/src/ListMmfBenchmarks/BenchmarkRandomWrites.cs
+++ b/src/ListMmfBenchmarks/BenchmarkRandomWrites.cs
@@ -21,7 +21,7 @@ public unsafe class BenchmarkRandomWrites
     {
         if (!Environment.Is64BitProcess)
         {
-            throw new Exception("Not supported on 32-bit process. Must be 64-bit for atomic operations on structures of size <= 8 bytes.");
+            throw new PlatformNotSupportedException("Requires a 64-bit process (x64 or ARM64).");
         }
         const string testFilePath = @"C:\_HugeArray\Timestamps.btd"; // 9.91 GB of longs
         NumTests = 10000000;

--- a/src/ListMmfBenchmarks/BenchmarkReadOnlyList64View.cs
+++ b/src/ListMmfBenchmarks/BenchmarkReadOnlyList64View.cs
@@ -1,4 +1,5 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿using System;
+using BenchmarkDotNet.Attributes;
 using BruSoftware.ListMmf;
 
 namespace ListMmfBenchmarks;
@@ -17,7 +18,7 @@ public class BenchmarkReadOnlyList64View
     {
         if (!Environment.Is64BitProcess)
         {
-            throw new Exception("Not supported on 32-bit process. Must be 64-bit for atomic operations on structures of size <= 8 bytes.");
+            throw new PlatformNotSupportedException("Requires a 64-bit process (x64 or ARM64).");
         }
         const string TestFilePath = @"C:\_HugeArray\Timestamps.btd"; // 9.91 GB of longs
         _listMmf = new ListMmf<long>(TestFilePath, DataType.Int64);

--- a/src/ListMmfBenchmarks/BenchmarkTwoViews.cs
+++ b/src/ListMmfBenchmarks/BenchmarkTwoViews.cs
@@ -23,7 +23,7 @@ public unsafe class BenchmarkTwoViews
     {
         if (!Environment.Is64BitProcess)
         {
-            throw new Exception("Not supported on 32-bit process. Must be 64-bit for atomic operations on structures of size <= 8 bytes.");
+            throw new PlatformNotSupportedException("Requires a 64-bit process (x64 or ARM64).");
         }
         const string testFilePath = @"C:\_HugeArray\Timestamps.btd"; // 9.91 GB of longs
         const int numTests = 10000000;

--- a/src/ListMmfBenchmarks/DebugAppend.cs
+++ b/src/ListMmfBenchmarks/DebugAppend.cs
@@ -19,7 +19,7 @@ public unsafe class DebugAppend
     {
         if (!Environment.Is64BitProcess)
         {
-            throw new Exception("Not supported on 32-bit process. Must be 64-bit for atomic operations on structures of size <= 8 bytes.");
+            throw new PlatformNotSupportedException("Requires a 64-bit process (x64 or ARM64).");
         }
         _testFilePath = @"C:\_HugeArray\TestApppend.dat";
         CreateMmf(1000);

--- a/src/ListMmfBenchmarks/ListMmfBenchmarks.csproj
+++ b/src/ListMmfBenchmarks/ListMmfBenchmarks.csproj
@@ -2,24 +2,25 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net9.0-windows</TargetFramework>
+                <TargetFramework>net9.0-windows</TargetFramework>
 		<RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
 		<RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
 		<LangVersion>preview</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Platforms>x64</Platforms>
-		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-		<StartupObject>ListMmfBenchmarks.Program</StartupObject>
-	</PropertyGroup>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <PlatformTarget>AnyCPU</PlatformTarget>
+                <Prefer32Bit>false</Prefer32Bit>
+                <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+                <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+                <StartupObject>ListMmfBenchmarks.Program</StartupObject>
+        </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.14.0"/>
-		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0"/>
-		<PackageReference Include="xunit" Version="2.9.3"/>
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.0"/>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-	</ItemGroup>
+                <PackageReference Include="BenchmarkDotNet" Version="0.14.0"/>
+                <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0"/>
+                <PackageReference Include="xunit" Version="2.9.3"/>
+                <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0"/>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        </ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\ListMmf\ListMmf.csproj"/>

--- a/src/ListMmfBenchmarks/TestPointerHugeFile.cs
+++ b/src/ListMmfBenchmarks/TestPointerHugeFile.cs
@@ -12,7 +12,7 @@ internal unsafe class TestPointerHugeFile
     {
         if (!Environment.Is64BitProcess)
         {
-            throw new Exception("Not supported on 32-bit process. Must be 64-bit for atomic operations on structures of size <= 8 bytes.");
+            throw new PlatformNotSupportedException("Requires a 64-bit process (x64 or ARM64).");
         }
         const string TestFilePath = @"C:\_HugeArray\TestWriteRead.btd"; // 9.91 GB of longs
         var count = (long)int.MaxValue * 2;

--- a/src/ListMmfTests/ListMmfTests.csproj
+++ b/src/ListMmfTests/ListMmfTests.csproj
@@ -3,14 +3,15 @@
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<LangVersion>preview</LangVersion>
-		<IsPackable>false</IsPackable>
-		<Platforms>x64</Platforms>
-		<Configurations>Debug;Release;Mixed</Configurations>
+                <IsPackable>false</IsPackable>
+                <PlatformTarget>AnyCPU</PlatformTarget>
+                <Prefer32Bit>false</Prefer32Bit>
+                <Configurations>Debug;Release;Mixed</Configurations>
 	</PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Mixed|x64' ">
-		<Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
-	</PropertyGroup>
+        <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Mixed|AnyCPU' ">
+                <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
+        </PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="8.0.1"/>


### PR DESCRIPTION
## Summary
- target AnyCPU for all projects and disable 32-bit preference
- keep explicit 64-bit guard and update messaging
- test on x64 and arm64 across OSes in CI

## Testing
- `dotnet test src/ListMmfTests/ListMmfTests.csproj --configuration Release --arch x64 --no-build --logger "trx;LogFileName=test-results.trx"`
- `dotnet test src/ListMmfTests/ListMmfTests.csproj --configuration Release --arch arm64 --no-build --logger "trx;LogFileName=test-results.trx"`


------
https://chatgpt.com/codex/tasks/task_e_68a251db76b8832880cc3f4297d0b67d