### PR TITLE
Promote AsSpan as the primary slicing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ var sharedList = new ListMmf<int>("shared-list");
 Console.WriteLine(sharedList.Count);  // 3
 ```
 
+### Zero-Copy Span Access
+
+```csharp
+// Inspect a window of data without allocating new arrays
+ReadOnlySpan<int> recent = sharedList.AsSpan(start: 1, length: 2);
+Console.WriteLine(recent[0]);
+```
+
+> [!NOTE]
+> Legacy callers can continue to use `GetRange` but the method now forwards to `AsSpan` internally.
+> Prefer the `AsSpan` overloads for new code so the zero-copy semantics are obvious at call sites.
+
 ### Time Series Data
 
 ```csharp

--- a/src/ListMmf/Interfaces/IReadOnlyList64Mmf.cs
+++ b/src/ListMmf/Interfaces/IReadOnlyList64Mmf.cs
@@ -19,23 +19,46 @@ public interface IReadOnlyList64Mmf<T> : IReadOnlyList64<T>
     T ReadUnchecked(long index);
 
     /// <summary>
-    /// Gets a read-only span representing a range of elements starting at the specified index.
-    /// This provides zero-copy access to the underlying memory-mapped data when possible,
-    /// or efficient bulk conversion for wrapper implementations.
+    /// Provides the primary zero-copy slicing API for the memory-mapped list.
+    /// Implementations should return a span view over the requested range without allocating
+    /// whenever the underlying storage permits it.
     /// </summary>
-    /// <param name="start">The zero-based starting index of the range</param>
-    /// <param name="length">The number of elements in the range</param>
-    /// <returns>A ReadOnlySpan containing the specified range of elements</returns>
-    /// <exception cref="ArgumentOutOfRangeException">If start or length is invalid</exception>
+    /// <param name="start">The zero-based starting index of the range.</param>
+    /// <param name="length">The number of elements in the range.</param>
+    /// <returns>A read-only span covering the requested range.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">If <paramref name="start"/> or <paramref name="length"/> is invalid.</exception>
+    ReadOnlySpan<T> AsSpan(long start, int length)
+    {
+        return GetRange(start, length);
+    }
+
+    /// <summary>
+    /// Provides the primary zero-copy slicing API for the memory-mapped list.
+    /// Implementations should return a span view from the requested start index to the end
+    /// of the list without allocating whenever possible.
+    /// </summary>
+    /// <param name="start">The zero-based starting index.</param>
+    /// <returns>A read-only span from <paramref name="start"/> to the end of the list.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">If <paramref name="start"/> is invalid.</exception>
+    ReadOnlySpan<T> AsSpan(long start)
+    {
+        return GetRange(start);
+    }
+
+    /// <summary>
+    /// Legacy alias retained for backward compatibility. Prefer <see cref="AsSpan(long,int)"/>.
+    /// </summary>
+    /// <remarks>This method will remain for existing callers but new code should use the AsSpan overloads.</remarks>
+    /// <param name="start">The zero-based starting index of the range.</param>
+    /// <param name="length">The number of elements in the range.</param>
+    /// <returns>A read-only span covering the requested range.</returns>
     ReadOnlySpan<T> GetRange(long start, int length);
 
     /// <summary>
-    /// Gets a read-only span from the specified start index to the end of the list.
-    /// This provides zero-copy access to the underlying memory-mapped data when possible,
-    /// or efficient bulk conversion for wrapper implementations.
+    /// Legacy alias retained for backward compatibility. Prefer <see cref="AsSpan(long)"/>.
     /// </summary>
-    /// <param name="start">The zero-based starting index</param>
-    /// <returns>A ReadOnlySpan from start to the end of the list</returns>
-    /// <exception cref="ArgumentOutOfRangeException">If start is invalid</exception>
+    /// <remarks>This method will remain for existing callers but new code should use the AsSpan overloads.</remarks>
+    /// <param name="start">The zero-based starting index.</param>
+    /// <returns>A read-only span from <paramref name="start"/> to the end of the list.</returns>
     ReadOnlySpan<T> GetRange(long start);
 }

--- a/src/ListMmf/ListMmf.csproj
+++ b/src/ListMmf/ListMmf.csproj
@@ -18,7 +18,7 @@
 		
 		<!-- NuGet Package Metadata -->
 		<PackageId>BruSoftware.ListMmf</PackageId>
-		<Version>1.0.4</Version>
+               <Version>1.0.5</Version>
 		<Authors>Dale A. Brubaker</Authors>
 		<Description>High-performance memory-mapped file implementation of .NET's IList&lt;T&gt; interface for inter-process communication and large data handling</Description>
 		<Copyright>Copyright © Dale A. Brubaker 2022-2025</Copyright>

--- a/src/ListMmf/ListMmfBase.cs
+++ b/src/ListMmf/ListMmfBase.cs
@@ -707,7 +707,7 @@ public unsafe class ListMmfBase<T> : ListMmfBaseDebug where T : struct
     /// <returns>A ReadOnlySpan&lt;T&gt; representing the requested range</returns>
     /// <exception cref="ArgumentOutOfRangeException">If start or length is invalid</exception>
     /// <exception cref="ListMmfOnlyInt32SupportedException">If length exceeds int.MaxValue</exception>
-    public ReadOnlySpan<T> GetRange(long start, int length)
+    public ReadOnlySpan<T> AsSpan(long start, int length)
     {
         // Bounds validation
         var count = Count;
@@ -737,7 +737,7 @@ public unsafe class ListMmfBase<T> : ListMmfBaseDebug where T : struct
     /// <returns>A ReadOnlySpan&lt;T&gt; representing elements from start to the end</returns>
     /// <exception cref="ArgumentOutOfRangeException">If start is invalid</exception>
     /// <exception cref="ListMmfOnlyInt32SupportedException">If the resulting length exceeds int.MaxValue</exception>
-    public ReadOnlySpan<T> GetRange(long start)
+    public ReadOnlySpan<T> AsSpan(long start)
     {
         var count = Count;
         var length = count - start;
@@ -746,7 +746,28 @@ public unsafe class ListMmfBase<T> : ListMmfBaseDebug where T : struct
             throw new ListMmfOnlyInt32SupportedException(length);
         }
 
-        return GetRange(start, (int)length);
+        return AsSpan(start, (int)length);
+    }
+
+    /// <summary>
+    /// Legacy alias retained for backward compatibility. Prefer <see cref="AsSpan(long,int)"/>.
+    /// </summary>
+    /// <param name="start">The starting index (inclusive)</param>
+    /// <param name="length">The number of elements to include in the span</param>
+    /// <returns>A ReadOnlySpan&lt;T&gt; representing the requested range</returns>
+    public ReadOnlySpan<T> GetRange(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    /// <summary>
+    /// Legacy alias retained for backward compatibility. Prefer <see cref="AsSpan(long)"/>.
+    /// </summary>
+    /// <param name="start">The starting index (inclusive)</param>
+    /// <returns>A ReadOnlySpan&lt;T&gt; representing elements from start to the end</returns>
+    public ReadOnlySpan<T> GetRange(long start)
+    {
+        return AsSpan(start);
     }
 
     /// <summary>

--- a/src/ListMmf/ListMmfBitArray.cs
+++ b/src/ListMmf/ListMmfBitArray.cs
@@ -469,7 +469,7 @@ public unsafe class ListMmfBitArray : ListMmfBase<int>, IListMmf<bool>, IReadOnl
     /// <returns>A Span&lt;bool&gt; representing the requested range</returns>
     /// <exception cref="ArgumentOutOfRangeException">If start or length is invalid</exception>
     /// <exception cref="ListMmfOnlyInt32SupportedException">If length exceeds int.MaxValue</exception>
-    public new Span<bool> GetRange(long start, int length)
+    public new Span<bool> AsSpan(long start, int length)
     {
         // Bounds validation
         var count = Length;
@@ -503,7 +503,7 @@ public unsafe class ListMmfBitArray : ListMmfBase<int>, IListMmf<bool>, IReadOnl
     /// <returns>A Span&lt;bool&gt; representing bits from start to the end</returns>
     /// <exception cref="ArgumentOutOfRangeException">If start is invalid</exception>
     /// <exception cref="ListMmfOnlyInt32SupportedException">If the resulting length exceeds int.MaxValue</exception>
-    public new Span<bool> GetRange(long start)
+    public new Span<bool> AsSpan(long start)
     {
         var count = Length;
         var length = count - start;
@@ -512,18 +512,38 @@ public unsafe class ListMmfBitArray : ListMmfBase<int>, IListMmf<bool>, IReadOnl
             throw new ListMmfOnlyInt32SupportedException(length);
         }
 
-        return GetRange(start, (int)length);
+        return AsSpan(start, (int)length);
+    }
+
+    public new Span<bool> GetRange(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    public new Span<bool> GetRange(long start)
+    {
+        return AsSpan(start);
     }
 
     // Explicit interface implementations for ReadOnlySpan return type
     ReadOnlySpan<bool> IReadOnlyList64Mmf<bool>.GetRange(long start, int length)
     {
-        return GetRange(start, length);
+        return AsSpan(start, length);
     }
 
     ReadOnlySpan<bool> IReadOnlyList64Mmf<bool>.GetRange(long start)
     {
-        return GetRange(start);
+        return AsSpan(start);
+    }
+
+    ReadOnlySpan<bool> IReadOnlyList64Mmf<bool>.AsSpan(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    ReadOnlySpan<bool> IReadOnlyList64Mmf<bool>.AsSpan(long start)
+    {
+        return AsSpan(start);
     }
 
     /// <summary>

--- a/src/ListMmf/ListMmfTimeSeriesDateTime.cs
+++ b/src/ListMmf/ListMmfTimeSeriesDateTime.cs
@@ -250,7 +250,7 @@ public class ListMmfTimeSeriesDateTime : ListMmfBase<long>, IReadOnlyList64Mmf<D
     /// <returns>A Span&lt;DateTime&gt; representing the requested range</returns>
     /// <exception cref="ArgumentOutOfRangeException">If start or length is invalid</exception>
     /// <exception cref="ListMmfOnlyInt32SupportedException">If length exceeds int.MaxValue</exception>
-    public new Span<DateTime> GetRange(long start, int length)
+    public new Span<DateTime> AsSpan(long start, int length)
     {
         // Bounds validation
         var count = Count;
@@ -273,7 +273,7 @@ public class ListMmfTimeSeriesDateTime : ListMmfBase<long>, IReadOnlyList64Mmf<D
         }
 
         // Use bulk read of underlying ticks data for better performance
-        var ticksSpan = base.GetRange(start, length);
+        var ticksSpan = base.AsSpan(start, length);
         var result = new DateTime[length];
 
         // Convert ticks to DateTime in bulk
@@ -293,7 +293,7 @@ public class ListMmfTimeSeriesDateTime : ListMmfBase<long>, IReadOnlyList64Mmf<D
     /// <returns>A Span&lt;DateTime&gt; representing elements from start to the end</returns>
     /// <exception cref="ArgumentOutOfRangeException">If start is invalid</exception>
     /// <exception cref="ListMmfOnlyInt32SupportedException">If the resulting length exceeds int.MaxValue</exception>
-    public new Span<DateTime> GetRange(long start)
+    public new Span<DateTime> AsSpan(long start)
     {
         var count = Count;
         if (start < 0 || start > count)
@@ -301,25 +301,38 @@ public class ListMmfTimeSeriesDateTime : ListMmfBase<long>, IReadOnlyList64Mmf<D
             throw new ArgumentOutOfRangeException(nameof(start));
         }
         var length = (int)(count - start);
-        return GetRange(start, length);
+        return AsSpan(start, length);
+    }
+
+    public new Span<DateTime> GetRange(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    public new Span<DateTime> GetRange(long start)
+    {
+        return AsSpan(start);
     }
 
     // Explicit interface implementations for ReadOnlySpan return type
     ReadOnlySpan<DateTime> IReadOnlyList64Mmf<DateTime>.GetRange(long start, int length)
     {
-        return GetRange(start, length);
+        return AsSpan(start, length);
     }
 
     ReadOnlySpan<DateTime> IReadOnlyList64Mmf<DateTime>.GetRange(long start)
     {
-        var count = Count;
-        var length = count - start;
-        if (length > int.MaxValue)
-        {
-            throw new ListMmfOnlyInt32SupportedException(length);
-        }
+        return AsSpan(start);
+    }
 
-        return GetRange(start, (int)length);
+    ReadOnlySpan<DateTime> IReadOnlyList64Mmf<DateTime>.AsSpan(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    ReadOnlySpan<DateTime> IReadOnlyList64Mmf<DateTime>.AsSpan(long start)
+    {
+        return AsSpan(start);
     }
 
     /// <summary>

--- a/src/ListMmf/ListMmfTimeSeriesDateTimeSeconds.cs
+++ b/src/ListMmf/ListMmfTimeSeriesDateTimeSeconds.cs
@@ -275,7 +275,7 @@ public class ListMmfTimeSeriesDateTimeSeconds : ListMmfBase<int>, IReadOnlyList6
     /// <returns>A Span&lt;DateTime&gt; representing the requested range</returns>
     /// <exception cref="ArgumentOutOfRangeException">If start or length is invalid</exception>
     /// <exception cref="ListMmfOnlyInt32SupportedException">If length exceeds int.MaxValue</exception>
-    public new Span<DateTime> GetRange(long start, int length)
+    public new Span<DateTime> AsSpan(long start, int length)
     {
         // Bounds validation
         var count = Count;
@@ -298,7 +298,7 @@ public class ListMmfTimeSeriesDateTimeSeconds : ListMmfBase<int>, IReadOnlyList6
         }
 
         // Use bulk read of underlying Unix seconds data for better performance
-        var secondsSpan = base.GetRange(start, length);
+        var secondsSpan = base.AsSpan(start, length);
         var result = new DateTime[length];
 
         // Convert Unix seconds to DateTime in bulk
@@ -318,7 +318,7 @@ public class ListMmfTimeSeriesDateTimeSeconds : ListMmfBase<int>, IReadOnlyList6
     /// <returns>A Span&lt;DateTime&gt; representing elements from start to the end</returns>
     /// <exception cref="ArgumentOutOfRangeException">If start is invalid</exception>
     /// <exception cref="ListMmfOnlyInt32SupportedException">If the resulting length exceeds int.MaxValue</exception>
-    public new Span<DateTime> GetRange(long start)
+    public new Span<DateTime> AsSpan(long start)
     {
         var count = Count;
         var length = count - start;
@@ -327,18 +327,38 @@ public class ListMmfTimeSeriesDateTimeSeconds : ListMmfBase<int>, IReadOnlyList6
             throw new ListMmfOnlyInt32SupportedException(length);
         }
 
-        return GetRange(start, (int)length);
+        return AsSpan(start, (int)length);
+    }
+
+    public new Span<DateTime> GetRange(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    public new Span<DateTime> GetRange(long start)
+    {
+        return AsSpan(start);
     }
 
     // Explicit interface implementations for ReadOnlySpan return type
     ReadOnlySpan<DateTime> IReadOnlyList64Mmf<DateTime>.GetRange(long start, int length)
     {
-        return GetRange(start, length);
+        return AsSpan(start, length);
     }
 
     ReadOnlySpan<DateTime> IReadOnlyList64Mmf<DateTime>.GetRange(long start)
     {
-        return GetRange(start);
+        return AsSpan(start);
+    }
+
+    ReadOnlySpan<DateTime> IReadOnlyList64Mmf<DateTime>.AsSpan(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    ReadOnlySpan<DateTime> IReadOnlyList64Mmf<DateTime>.AsSpan(long start)
+    {
+        return AsSpan(start);
     }
 
     /// <summary>
@@ -456,7 +476,7 @@ public class ListMmfTimeSeriesDateTimeSeconds : ListMmfBase<int>, IReadOnlyList6
             var startIndex = remaining - currentChunkSize;
 
             // Get a chunk of underlying Unix seconds data
-            var chunk = base.GetRange(startIndex, currentChunkSize);
+            var chunk = base.AsSpan(startIndex, currentChunkSize);
 
             // Search backwards within this chunk
             for (var i = chunk.Length - 1; i >= 0; i--)
@@ -496,7 +516,7 @@ public class ListMmfTimeSeriesDateTimeSeconds : ListMmfBase<int>, IReadOnlyList6
             var startIndex = remaining - currentChunkSize;
 
             // Get a chunk of underlying Unix seconds data
-            var chunk = base.GetRange(startIndex, currentChunkSize);
+            var chunk = base.AsSpan(startIndex, currentChunkSize);
 
             // Search backwards within this chunk
             for (var i = chunk.Length - 1; i >= 0; i--)

--- a/src/ListMmf/ReadOnlyList64Extensions.cs
+++ b/src/ListMmf/ReadOnlyList64Extensions.cs
@@ -68,6 +68,34 @@ public static class ReadOnlyList64Extensions
     }
 
     /// <summary>
+    /// Provides a span view over a portion of the list without allocating.
+    /// Alias for <see cref="IReadOnlyList64Mmf{T}.AsSpan(long,int)"/> to align with .NET span naming conventions.
+    /// </summary>
+    public static ReadOnlySpan<T> AsSpan<T>(this IReadOnlyList64Mmf<T> list, long start, int length)
+    {
+        if (list == null)
+        {
+            throw new ArgumentNullException(nameof(list));
+        }
+
+        return list.AsSpan(start, length);
+    }
+
+    /// <summary>
+    /// Provides a span view from the specified start index to the end without allocating.
+    /// Alias for <see cref="IReadOnlyList64Mmf{T}.AsSpan(long)"/>.
+    /// </summary>
+    public static ReadOnlySpan<T> AsSpan<T>(this IReadOnlyList64Mmf<T> list, long start)
+    {
+        if (list == null)
+        {
+            throw new ArgumentNullException(nameof(list));
+        }
+
+        return list.AsSpan(start);
+    }
+
+    /// <summary>
     /// Convert an array or list of double to an array of floats.
     /// </summary>
     /// <param name="values"></param>

--- a/src/ListMmf/ReadOnlyList64Mmf.cs
+++ b/src/ListMmf/ReadOnlyList64Mmf.cs
@@ -21,14 +21,24 @@ public class ReadOnlyList64Mmf<T>(IReadOnlyList64Mmf<T> list) : IReadOnlyList64M
         return _list.ReadUnchecked(index);
     }
 
+    public ReadOnlySpan<T> AsSpan(long start, int length)
+    {
+        return _list.AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<T> AsSpan(long start)
+    {
+        return _list.AsSpan(start);
+    }
+
     public ReadOnlySpan<T> GetRange(long start, int length)
     {
-        return _list.GetRange(start, length);
+        return _list.AsSpan(start, length);
     }
 
     public ReadOnlySpan<T> GetRange(long start)
     {
-        return _list.GetRange(start);
+        return _list.AsSpan(start);
     }
 
     public override string ToString()

--- a/src/ListMmf/ReadOnlyList64MmfView.cs
+++ b/src/ListMmf/ReadOnlyList64MmfView.cs
@@ -70,7 +70,7 @@ public class ReadOnlyList64MmfView<T> : IReadOnlyList64Mmf<T>
         return _list.ReadUnchecked(absoluteIndex);
     }
 
-    public ReadOnlySpan<T> GetRange(long start, int length)
+    public ReadOnlySpan<T> AsSpan(long start, int length)
     {
         // Adjust for the view's lower bound and get range from underlying list
         var absoluteStart = _lowerBound + start;
@@ -78,18 +78,29 @@ public class ReadOnlyList64MmfView<T> : IReadOnlyList64Mmf<T>
         {
             throw new ArgumentOutOfRangeException(nameof(start));
         }
-        return _list.GetRange(absoluteStart, length);
+        return _list.AsSpan(absoluteStart, length);
     }
 
-    public ReadOnlySpan<T> GetRange(long start)
+    public ReadOnlySpan<T> AsSpan(long start)
     {
         var count = Count;
         if (start < 0 || start >= count)
         {
             throw new ArgumentOutOfRangeException(nameof(start));
         }
+
         var length = (int)(count - start);
-        return GetRange(start, length);
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<T> GetRange(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<T> GetRange(long start)
+    {
+        return AsSpan(start);
     }
 
     public override string ToString()

--- a/src/ListMmf/ReadOnlyLists/ReadOnlyList64BTLongFromByte.cs
+++ b/src/ListMmf/ReadOnlyLists/ReadOnlyList64BTLongFromByte.cs
@@ -59,10 +59,10 @@ public class ReadOnlyList64MmfLongFromByte : IReadOnlyList64Mmf<long>
         return _list.ReadUnchecked(index);
     }
 
-    public ReadOnlySpan<long> GetRange(long start, int length)
+    public ReadOnlySpan<long> AsSpan(long start, int length)
     {
         // Get the underlying data in bulk and convert
-        var byteSpan = _list.GetRange(start, length);
+        var byteSpan = _list.AsSpan(start, length);
         var result = new long[length];
         for (int i = 0; i < length; i++)
         {
@@ -71,7 +71,7 @@ public class ReadOnlyList64MmfLongFromByte : IReadOnlyList64Mmf<long>
         return result;
     }
 
-    public ReadOnlySpan<long> GetRange(long start)
+    public ReadOnlySpan<long> AsSpan(long start)
     {
         var count = Count;
         if (start < 0 || start >= count)
@@ -79,7 +79,17 @@ public class ReadOnlyList64MmfLongFromByte : IReadOnlyList64Mmf<long>
             throw new ArgumentOutOfRangeException(nameof(start));
         }
         var length = (int)(count - start);
-        return GetRange(start, length);
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<long> GetRange(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<long> GetRange(long start)
+    {
+        return AsSpan(start);
     }
 
     public override string ToString()

--- a/src/ListMmf/ReadOnlyLists/ReadOnlyList64LongFromInt.cs
+++ b/src/ListMmf/ReadOnlyLists/ReadOnlyList64LongFromInt.cs
@@ -59,10 +59,10 @@ public class ReadOnlyList64MmfIntToLong : IReadOnlyList64Mmf<long>
         return _list.ReadUnchecked(index);
     }
 
-    public ReadOnlySpan<long> GetRange(long start, int length)
+    public ReadOnlySpan<long> AsSpan(long start, int length)
     {
         // Get the underlying data in bulk and convert
-        var intSpan = _list.GetRange(start, length);
+        var intSpan = _list.AsSpan(start, length);
         var result = new long[length];
         for (int i = 0; i < length; i++)
         {
@@ -71,7 +71,7 @@ public class ReadOnlyList64MmfIntToLong : IReadOnlyList64Mmf<long>
         return result;
     }
 
-    public ReadOnlySpan<long> GetRange(long start)
+    public ReadOnlySpan<long> AsSpan(long start)
     {
         var count = Count;
         if (start < 0 || start >= count)
@@ -79,7 +79,17 @@ public class ReadOnlyList64MmfIntToLong : IReadOnlyList64Mmf<long>
             throw new ArgumentOutOfRangeException(nameof(start));
         }
         var length = (int)(count - start);
-        return GetRange(start, length);
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<long> GetRange(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<long> GetRange(long start)
+    {
+        return AsSpan(start);
     }
 
     public override string ToString()

--- a/src/ListMmf/ReadOnlyLists/ReadOnlyList64MmfCalculated.cs
+++ b/src/ListMmf/ReadOnlyLists/ReadOnlyList64MmfCalculated.cs
@@ -54,14 +54,14 @@ public class ReadOnlyList64MmfCalculated<T> : IReadOnlyList64Mmf<T> where T : st
         return _funcGetCalculatedValueAtIndex(index);
     }
 
-    public ReadOnlySpan<T> GetRange(long start, int length)
+    public ReadOnlySpan<T> AsSpan(long start, int length)
     {
         // For calculated lists, we must compute each value individually
         if (start < 0 || start + length > Count)
         {
             throw new ArgumentOutOfRangeException(nameof(start));
         }
-        
+
         var result = new T[length];
         for (int i = 0; i < length; i++)
         {
@@ -70,7 +70,7 @@ public class ReadOnlyList64MmfCalculated<T> : IReadOnlyList64Mmf<T> where T : st
         return result;
     }
 
-    public ReadOnlySpan<T> GetRange(long start)
+    public ReadOnlySpan<T> AsSpan(long start)
     {
         var count = Count;
         if (start < 0 || start >= count)
@@ -78,7 +78,17 @@ public class ReadOnlyList64MmfCalculated<T> : IReadOnlyList64Mmf<T> where T : st
             throw new ArgumentOutOfRangeException(nameof(start));
         }
         var length = (int)(count - start);
-        return GetRange(start, length);
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<T> GetRange(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<T> GetRange(long start)
+    {
+        return AsSpan(start);
     }
 
     public override string ToString()

--- a/src/ListMmf/ReadOnlyLists/ReadOnlyList64MmfIntFromLong.cs
+++ b/src/ListMmf/ReadOnlyLists/ReadOnlyList64MmfIntFromLong.cs
@@ -59,10 +59,10 @@ public class ReadOnlyList64MmfIntFromLong : IReadOnlyList64Mmf<int>
         return (int)_list.ReadUnchecked(index);
     }
 
-    public ReadOnlySpan<int> GetRange(long start, int length)
+    public ReadOnlySpan<int> AsSpan(long start, int length)
     {
         // Get the underlying data in bulk and convert
-        var longSpan = _list.GetRange(start, length);
+        var longSpan = _list.AsSpan(start, length);
         var result = new int[length];
         for (int i = 0; i < length; i++)
         {
@@ -71,7 +71,7 @@ public class ReadOnlyList64MmfIntFromLong : IReadOnlyList64Mmf<int>
         return result;
     }
 
-    public ReadOnlySpan<int> GetRange(long start)
+    public ReadOnlySpan<int> AsSpan(long start)
     {
         var count = Count;
         if (start < 0 || start >= count)
@@ -79,7 +79,17 @@ public class ReadOnlyList64MmfIntFromLong : IReadOnlyList64Mmf<int>
             throw new ArgumentOutOfRangeException(nameof(start));
         }
         var length = (int)(count - start);
-        return GetRange(start, length);
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<int> GetRange(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<int> GetRange(long start)
+    {
+        return AsSpan(start);
     }
 
     public override string ToString()

--- a/src/ListMmf/ReadOnlyLists/ReadOnlyList64MmfLongFromUShort.cs
+++ b/src/ListMmf/ReadOnlyLists/ReadOnlyList64MmfLongFromUShort.cs
@@ -59,10 +59,10 @@ public class ReadOnlyList64MmfLongFromUShort : IReadOnlyList64Mmf<long>
         return _list.ReadUnchecked(index);
     }
 
-    public ReadOnlySpan<long> GetRange(long start, int length)
+    public ReadOnlySpan<long> AsSpan(long start, int length)
     {
         // Get the underlying data in bulk and convert
-        var ushortSpan = _list.GetRange(start, length);
+        var ushortSpan = _list.AsSpan(start, length);
         var result = new long[length];
         for (int i = 0; i < length; i++)
         {
@@ -71,7 +71,7 @@ public class ReadOnlyList64MmfLongFromUShort : IReadOnlyList64Mmf<long>
         return result;
     }
 
-    public ReadOnlySpan<long> GetRange(long start)
+    public ReadOnlySpan<long> AsSpan(long start)
     {
         var count = Count;
         if (start < 0 || start >= count)
@@ -79,7 +79,17 @@ public class ReadOnlyList64MmfLongFromUShort : IReadOnlyList64Mmf<long>
             throw new ArgumentOutOfRangeException(nameof(start));
         }
         var length = (int)(count - start);
-        return GetRange(start, length);
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<long> GetRange(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<long> GetRange(long start)
+    {
+        return AsSpan(start);
     }
 
     public override string ToString()

--- a/src/ListMmf/ReadOnlyLists/ReadOnlyList64MmfLongFromUint.cs
+++ b/src/ListMmf/ReadOnlyLists/ReadOnlyList64MmfLongFromUint.cs
@@ -59,10 +59,10 @@ public class ReadOnlyList64MmfLongFromUint : IReadOnlyList64Mmf<long>
         return _list.ReadUnchecked(index);
     }
 
-    public ReadOnlySpan<long> GetRange(long start, int length)
+    public ReadOnlySpan<long> AsSpan(long start, int length)
     {
         // Get the underlying data in bulk and convert
-        var uintSpan = _list.GetRange(start, length);
+        var uintSpan = _list.AsSpan(start, length);
         var result = new long[length];
         for (int i = 0; i < length; i++)
         {
@@ -71,7 +71,7 @@ public class ReadOnlyList64MmfLongFromUint : IReadOnlyList64Mmf<long>
         return result;
     }
 
-    public ReadOnlySpan<long> GetRange(long start)
+    public ReadOnlySpan<long> AsSpan(long start)
     {
         var count = Count;
         if (start < 0 || start >= count)
@@ -79,7 +79,17 @@ public class ReadOnlyList64MmfLongFromUint : IReadOnlyList64Mmf<long>
             throw new ArgumentOutOfRangeException(nameof(start));
         }
         var length = (int)(count - start);
-        return GetRange(start, length);
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<long> GetRange(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<long> GetRange(long start)
+    {
+        return AsSpan(start);
     }
 
     public override string ToString()

--- a/src/ListMmf/SmallestEnumListMmf.cs
+++ b/src/ListMmf/SmallestEnumListMmf.cs
@@ -136,10 +136,10 @@ public class SmallestEnumListMmf<T> : IListMmf<T>, IReadOnlyList64Mmf<T> where T
         return result;
     }
 
-    public ReadOnlySpan<T> GetRange(long start, int length)
+    public ReadOnlySpan<T> AsSpan(long start, int length)
     {
         // Get the underlying long data in bulk and convert to enum
-        var longSpan = _smallestInt64ListMmf.GetRange(start, length);
+        var longSpan = _smallestInt64ListMmf.AsSpan(start, length);
         var result = new T[length];
         for (int i = 0; i < length; i++)
         {
@@ -149,7 +149,7 @@ public class SmallestEnumListMmf<T> : IListMmf<T>, IReadOnlyList64Mmf<T> where T
         return result;
     }
 
-    public ReadOnlySpan<T> GetRange(long start)
+    public ReadOnlySpan<T> AsSpan(long start)
     {
         var count = Count;
         if (start < 0 || start >= count)
@@ -157,7 +157,17 @@ public class SmallestEnumListMmf<T> : IListMmf<T>, IReadOnlyList64Mmf<T> where T
             throw new ArgumentOutOfRangeException(nameof(start));
         }
         var length = (int)(count - start);
-        return GetRange(start, length);
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<T> GetRange(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<T> GetRange(long start)
+    {
+        return AsSpan(start);
     }
 
     public override string ToString()

--- a/src/ListMmf/SmallestInt64ListMmf.cs
+++ b/src/ListMmf/SmallestInt64ListMmf.cs
@@ -299,15 +299,15 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
         }
     }
 
-    public ReadOnlySpan<long> GetRange(long start, int length)
+    public ReadOnlySpan<long> AsSpan(long start, int length)
     {
         lock (_lock)
         {
-            return _underlying.GetRange(start, length);
+            return _underlying.AsSpan(start, length);
         }
     }
 
-    public ReadOnlySpan<long> GetRange(long start)
+    public ReadOnlySpan<long> AsSpan(long start)
     {
         lock (_lock)
         {
@@ -317,8 +317,18 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
                 throw new ArgumentOutOfRangeException(nameof(start));
             }
             var length = (int)(count - start);
-            return _underlying.GetRange(start, length);
+            return _underlying.AsSpan(start, length);
         }
+    }
+
+    public ReadOnlySpan<long> GetRange(long start, int length)
+    {
+        return AsSpan(start, length);
+    }
+
+    public ReadOnlySpan<long> GetRange(long start)
+    {
+        return AsSpan(start);
     }
 
     private void UpgradeIfRequired(long value)
@@ -839,12 +849,12 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             return _funcReadUnchecked(index);
         }
 
-        public ReadOnlySpan<long> GetRange(long start, int length)
+        public ReadOnlySpan<long> AsSpan(long start, int length)
         {
             return _funcGetRange(start, length);
         }
 
-        public ReadOnlySpan<long> GetRange(long start)
+        public ReadOnlySpan<long> AsSpan(long start)
         {
             var count = Count;
             if (start < 0 || start >= count)
@@ -853,6 +863,16 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             }
             var length = (int)(count - start);
             return _funcGetRange(start, length);
+        }
+
+        public ReadOnlySpan<long> GetRange(long start, int length)
+        {
+            return AsSpan(start, length);
+        }
+
+        public ReadOnlySpan<long> GetRange(long start)
+        {
+            return AsSpan(start);
         }
 
         private void SetEmptyArray()
@@ -879,7 +899,7 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             _funcReadUnchecked = x => list.ReadUnchecked(x);
             _funcGetRange = (start, length) =>
             {
-                var sourceSpan = list.GetRange(start, length);
+                var sourceSpan = list.AsSpan(start, length);
                 var result = new long[length];
                 for (var i = 0; i < length; i++)
                 {
@@ -912,7 +932,7 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             _funcReadUnchecked = x => list.ReadUnchecked(x);
             _funcGetRange = (start, length) =>
             {
-                var sourceSpan = list.GetRange(start, length);
+                var sourceSpan = list.AsSpan(start, length);
                 var result = new long[length];
                 for (var i = 0; i < length; i++)
                 {
@@ -945,7 +965,7 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             _funcReadUnchecked = x => list.ReadUnchecked(x);
             _funcGetRange = (start, length) =>
             {
-                var sourceSpan = list.GetRange(start, length);
+                var sourceSpan = list.AsSpan(start, length);
                 var result = new long[length];
                 for (var i = 0; i < length; i++)
                 {
@@ -976,7 +996,7 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             };
             _funcIndexer = x => list[x];
             _funcReadUnchecked = x => list.ReadUnchecked(x);
-            _funcGetRange = (start, length) => list.GetRange(start, length); // Direct access - no conversion needed
+            _funcGetRange = (start, length) => list.AsSpan(start, length); // Direct access - no conversion needed
             _actionAddRange = x =>
             {
                 var range = x.Select(y => y);
@@ -1010,7 +1030,7 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             };
             _funcGetRange = (start, length) =>
             {
-                var sourceSpan = list.GetRange(start, length);
+                var sourceSpan = list.AsSpan(start, length);
                 var result = new long[length];
                 for (var i = 0; i < length; i++)
                 {
@@ -1047,7 +1067,7 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             _funcReadUnchecked = x => list.ReadUnchecked(x);
             _funcGetRange = (start, length) =>
             {
-                var sourceSpan = list.GetRange(start, length);
+                var sourceSpan = list.AsSpan(start, length);
                 var result = new long[length];
                 for (var i = 0; i < length; i++)
                 {
@@ -1080,7 +1100,7 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             _funcReadUnchecked = x => list.ReadUnchecked(x);
             _funcGetRange = (start, length) =>
             {
-                var sourceSpan = list.GetRange(start, length);
+                var sourceSpan = list.AsSpan(start, length);
                 var result = new long[length];
                 for (var i = 0; i < length; i++)
                 {
@@ -1113,7 +1133,7 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             _funcReadUnchecked = x => list.ReadUnchecked(x);
             _funcGetRange = (start, length) =>
             {
-                var sourceSpan = list.GetRange(start, length);
+                var sourceSpan = list.AsSpan(start, length);
                 var result = new long[length];
                 for (var i = 0; i < length; i++)
                 {
@@ -1146,7 +1166,7 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             _funcReadUnchecked = x => list.ReadUnchecked(x);
             _funcGetRange = (start, length) =>
             {
-                var sourceSpan = list.GetRange(start, length);
+                var sourceSpan = list.AsSpan(start, length);
                 var result = new long[length];
                 for (var i = 0; i < length; i++)
                 {
@@ -1179,7 +1199,7 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             _funcReadUnchecked = x => list.ReadUnchecked(x);
             _funcGetRange = (start, length) =>
             {
-                var sourceSpan = list.GetRange(start, length);
+                var sourceSpan = list.AsSpan(start, length);
                 var result = new long[length];
                 for (var i = 0; i < length; i++)
                 {
@@ -1212,7 +1232,7 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             _funcReadUnchecked = x => list.ReadUnchecked(x);
             _funcGetRange = (start, length) =>
             {
-                var sourceSpan = list.GetRange(start, length);
+                var sourceSpan = list.AsSpan(start, length);
                 var result = new long[length];
                 for (var i = 0; i < length; i++)
                 {
@@ -1245,7 +1265,7 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             _funcReadUnchecked = x => list.ReadUnchecked(x);
             _funcGetRange = (start, length) =>
             {
-                var sourceSpan = list.GetRange(start, length);
+                var sourceSpan = list.AsSpan(start, length);
                 var result = new long[length];
                 for (var i = 0; i < length; i++)
                 {
@@ -1278,7 +1298,7 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             _funcReadUnchecked = x => list.ReadUnchecked(x);
             _funcGetRange = (start, length) =>
             {
-                var sourceSpan = list.GetRange(start, length);
+                var sourceSpan = list.AsSpan(start, length);
                 var result = new long[length];
                 for (var i = 0; i < length; i++)
                 {
@@ -1311,7 +1331,7 @@ public class SmallestInt64ListMmf : IListMmf<long>, IReadOnlyList64Mmf<long>
             _funcReadUnchecked = x => list.ReadUnchecked(x);
             _funcGetRange = (start, length) =>
             {
-                var sourceSpan = list.GetRange(start, length);
+                var sourceSpan = list.AsSpan(start, length);
                 var result = new long[length];
                 for (var i = 0; i < length; i++)
                 {

--- a/src/ListMmf/SmallestInt64ListMmfOptimized.cs
+++ b/src/ListMmf/SmallestInt64ListMmfOptimized.cs
@@ -100,8 +100,8 @@ public static class SmallestInt64ListMmfOptimized
         {
             var remainingCount = Math.Min(chunkSize, count - startIndex);
 
-            // Read chunk of values using GetRange for much better performance
-            var sourceSpan = source.GetRange(startIndex, (int)remainingCount);
+            // Read chunk of values using AsSpan for much better performance
+            var sourceSpan = source.AsSpan(startIndex, (int)remainingCount);
             sourceSpan.CopyTo(values.AsSpan(0, (int)remainingCount));
 
             // Bulk add the chunk (much more efficient than individual Add() calls)

--- a/src/ListMmf/UtilsListMmf.cs
+++ b/src/ListMmf/UtilsListMmf.cs
@@ -266,7 +266,7 @@ public static class UtilsListMmf
             var remainingCount = Math.Min(chunkSize, source.Count - startIndex);
 
             // Read chunk using GetRange for better performance (like BulkCopyValues)
-            var sourceSpan = source.GetRange(startIndex, (int)remainingCount);
+            var sourceSpan = source.AsSpan(startIndex, (int)remainingCount);
             sourceSpan.CopyTo(values.AsSpan(0, (int)remainingCount));
 
             // Bulk add the chunk (much more efficient than individual Add() calls)
@@ -292,7 +292,7 @@ public static class UtilsListMmf
             var remainingCount = Math.Min(chunkSize, source.Count - startIndex);
 
             // Read chunk using GetRange for better performance
-            var sourceSpan = source.GetRange(startIndex, (int)remainingCount);
+            var sourceSpan = source.AsSpan(startIndex, (int)remainingCount);
             sourceSpan.CopyTo(values.AsSpan(0, (int)remainingCount));
 
             // Bulk add the chunk

--- a/src/ListMmfTests/SpanSupportTests.cs
+++ b/src/ListMmfTests/SpanSupportTests.cs
@@ -56,6 +56,51 @@ public class SpanSupportTests : IDisposable
     }
 
     [Fact]
+    public void AsSpan_Alias_ReturnsSameData()
+    {
+        // Arrange
+        var path = GetTempFilePath("test_asspan_alias.mmf");
+        using var list = new ListMmf<int>(path, DataType.Int32);
+
+        var testData = new[] { 1, 2, 3, 4, 5 };
+        foreach (var item in testData)
+        {
+            list.Add(item);
+        }
+
+        // Act
+        var getRangeSpan = list.GetRange(1, 3);
+        var aliasSpan = list.AsSpan(1, 3);
+
+        // Assert
+        Assert.Equal(getRangeSpan.ToArray(), aliasSpan.ToArray());
+    }
+
+    [Fact]
+    public void AsSpan_InterfaceExtension_UsesImplementation()
+    {
+        // Arrange
+        var path = GetTempFilePath("test_asspan_interface.mmf");
+        using var list = new ListMmf<int>(path, DataType.Int32);
+
+        var testData = new[] { 10, 20, 30, 40 };
+        foreach (var item in testData)
+        {
+            list.Add(item);
+        }
+
+        IReadOnlyList64Mmf<int> asInterface = list;
+
+        // Act
+        var spanFromAlias = asInterface.AsSpan(0, 2);
+
+        // Assert
+        Assert.Equal(2, spanFromAlias.Length);
+        Assert.Equal(10, spanFromAlias[0]);
+        Assert.Equal(20, spanFromAlias[1]);
+    }
+
+    [Fact]
     public void GetRange_StartToEnd_ReturnsCorrectSpan()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- make `AsSpan` the primary zero-copy implementation across the memory-mapped collections while keeping `GetRange` as a compatibility shim
- update views, adapters, and helper utilities to forward through the new `AsSpan` surface and expose explicit interface members where needed
- document the naming shift and refresh tests to reflect the preferred entry points

## Testing
- ⚠️ `dotnet test src/ListMmfTests/ListMmfTests.csproj -c Release` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d69297d6a08328a669be47482d3395